### PR TITLE
Remove Alt-< and Alt-> from emacsy keymap.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -717,8 +717,6 @@ export const insertTab: StateCommand = ({state, dispatch}) => {
 ///  - Ctrl-Alt-h: [`deleteGroupBackward`](#commands.deleteGroupBackward)
 ///  - Ctrl-o: [`splitLine`](#commands.splitLine)
 ///  - Ctrl-t: [`transposeChars`](#commands.transposeChars)
-///  - Alt-<: [`cursorDocStart`](#commands.cursorDocStart)
-///  - Alt->: [`cursorDocEnd`](#commands.cursorDocEnd)
 ///  - Ctrl-v: [`cursorPageDown`](#commands.cursorPageDown)
 ///  - Alt-v: [`cursorPageUp`](#commands.cursorPageUp)
 export const emacsStyleKeymap: readonly KeyBinding[] = [
@@ -738,9 +736,6 @@ export const emacsStyleKeymap: readonly KeyBinding[] = [
 
   {key: "Ctrl-o", run: splitLine},
   {key: "Ctrl-t", run: transposeChars},
-
-  {key: "Alt-<", run: cursorDocStart},
-  {key: "Alt->", run: cursorDocEnd},
 
   {key: "Ctrl-v", run: cursorPageDown},
   {key: "Alt-v", run: cursorPageUp},


### PR DESCRIPTION
Based on my research, these don't seem to be bound by default (at least according to [this list](https://jblevins.org/log/kbd)).
They don't seem to be present in the CM5 emacsy keys list either: https://github.com/codemirror/CodeMirror/blob/master/src/input/keymap.js#L30

We've also gotten reports that this conflicts with inputting some characters.