### PR TITLE
Remove Alt-v from emacsy keymap.

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -749,7 +749,6 @@ export const emacsStyleKeymap: readonly KeyBinding[] = [
   {key: "Ctrl-t", run: transposeChars},
 
   {key: "Ctrl-v", run: cursorPageDown},
-  {key: "Alt-v", run: cursorPageUp},
 ]
 
 /// An array of key bindings closely sticking to platform-standard or


### PR DESCRIPTION
According to [the previous reference for macOS emacsy keys](https://jblevins.org/log/kbd) `Alt-V` is not implemented on macOS for pageup.
Weirdly `Ctrl-V` is implemented for pagedown.
According to reports, `Alt-V` is normally used for character input for some keyboard layouts.
https://forum.obsidian.md/t/alt-v-character-gets-hijacked-cursor-jumps-to-top/30987

![image](https://user-images.githubusercontent.com/609710/151230257-74fef9e5-9c2f-4d77-b1be-b096b1da2616.png)
