### PR TITLE
Mod-Shift-z to redo on Linux

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -381,12 +381,12 @@ class HistoryState {
 /// Default key bindings for the undo history.
 ///
 /// - Mod-z: [`undo`](#commands.undo).
-/// - Mod-y (Mod-Shift-z on macOS): [`redo`](#commands.redo).
+/// - Mod-Shift-z (Mod-y on Windows): [`redo`](#commands.redo).
 /// - Mod-u: [`undoSelection`](#commands.undoSelection).
 /// - Alt-u (Mod-Shift-u on macOS): [`redoSelection`](#commands.redoSelection).
 export const historyKeymap: readonly KeyBinding[] = [
   {key: "Mod-z", run: undo, preventDefault: true},
-  {key: "Mod-y", mac: "Mod-Shift-z", run: redo, preventDefault: true},
+  {key: "Mod-Shift-z", win: "Mod-y": run: redo, preventDefault: true},
   {key: "Mod-u", run: undoSelection, preventDefault: true},
   {key: "Alt-u", mac: "Mod-Shift-u", run: redoSelection, preventDefault: true}
 ]


### PR DESCRIPTION
On Linux Ctrl-Shift-Z is way more common that Ctr-Y to redo.

The best source I could find to support this claim is that Qt uses it by default for X11: https://github.com/qt/qtbase/blob/067b53864112c084587fa9a507eb4bde3d50a6e1/src/gui/kernel/qplatformtheme.cpp#L197