### PR TITLE
Fix inheriting indentation containing tabs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -677,7 +677,7 @@ function newlineAndIndent(atEof: boolean): StateCommand {
       if (atEof) from = to = (to <= line.to ? line : state.doc.lineAt(to)).to
       let cx = new IndentContext(state, {simulateBreak: from, simulateDoubleBreak: !!explode})
       let indent = getIndentation(cx, from)
-      if (indent == null) indent = /^\s*/.exec(state.doc.lineAt(from).text)![0].length
+      if (indent == null) indent = /^\s*/.exec(state.doc.lineAt(from).text)![0].split('').reduce((acc, char) => acc + (char === '\t' ? state.tabSize : 1), 0)
 
       while (to < line.to && /\s/.test(line.text[to - line.from])) to++
       if (explode) ({from, to} = explode)


### PR DESCRIPTION
Pressing Enter key on a line indented with tabs would previously indent the new line with one space for each tab, contrary to what the reference says:

> A return value of null indicates no indentation can be determined, and the line should inherit the indentation of the one above it.

This made using many `StreamLanguage`s with tabs annoying, requiring to define a custom `indentService` facet.

This does not help with mixed indentation (e.g. tabs for indentation + spaces for alignment) but proper support for that would probably require changes to `@codemirror/language`. People who need it can always implement it later.
